### PR TITLE
Selfie: Fix crash on no zoom capabilities

### DIFF
--- a/app/src/main/java/org/lineageos/selfie/MainActivity.kt
+++ b/app/src/main/java/org/lineageos/selfie/MainActivity.kt
@@ -451,6 +451,10 @@ class MainActivity : AppCompatActivity() {
         // Observe zoom state
         cameraController.zoomState.removeObservers(this)
         cameraController.zoomState.observe(this) {
+            if (it.minZoomRatio == it.maxZoomRatio) {
+                return@observe
+            }
+
             zoomLevel.valueFrom = it.minZoomRatio
             zoomLevel.valueTo = it.maxZoomRatio
             zoomLevel.value = it.zoomRatio


### PR DESCRIPTION
* On a cheap Allwinner tablet that I have minZoomRatio and maxZoomRatio returns 1.0 on front camera and BaseSlider isn't happy about it

Change-Id: If5a363ed767c34cf59d4fec9eabcd0d85c2a35df