### PR TITLE
Selfie: Default to CAPTURE_MODE_MINIMIZE_LATENCY

### DIFF
--- a/app/src/main/java/org/lineageos/selfie/SharedPreferencesExt.kt
+++ b/app/src/main/java/org/lineageos/selfie/SharedPreferencesExt.kt
@@ -113,7 +113,7 @@ internal var SharedPreferences.lastGridMode: GridMode
 
 // Photos prefs
 private const val PHOTO_CAPTURE_MODE_KEY = "photo_capture_mode"
-private const val PHOTO_CAPTURE_MODE_DEFAULT = "maximize_quality"
+private const val PHOTO_CAPTURE_MODE_DEFAULT = "minimize_latency"
 
 internal var SharedPreferences.photoCaptureMode: Int
     @androidx.camera.core.ExperimentalZeroShutterLag
@@ -122,8 +122,8 @@ internal var SharedPreferences.photoCaptureMode: Int
             "maximize_quality" -> ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY
             "minimize_latency" -> ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY
             "zero_shutter_lag" -> ImageCapture.CAPTURE_MODE_ZERO_SHUTTER_LAG
-            // Default to maximize quality
-            else -> ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY
+            // Default to minimize latency
+            else -> ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY
         }
     }
     @androidx.camera.core.ExperimentalZeroShutterLag

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -3,7 +3,7 @@
     <PreferenceCategory app:title="@string/photos_header">
 
         <ListPreference
-            app:defaultValue="maximize_quality"
+            app:defaultValue="minimize_latency"
             app:entries="@array/photo_capture_mode_entries"
             app:entryValues="@array/photo_capture_mode_values"
             app:key="photo_capture_mode"


### PR DESCRIPTION
This is the most convenient capture mode and if user wants
CAPTURE_MODE_MAXIMIZE_QUALITY, they can set it in settings.

Change-Id: I2400b95adcf98f5bd4937d1dd5d9acac6995d602