### PR TITLE
Selfie: Fix crash after double tapping shutter button in video mode

### DIFF
--- a/app/src/main/java/org/lineageos/selfie/MainActivity.kt
+++ b/app/src/main/java/org/lineageos/selfie/MainActivity.kt
@@ -66,6 +66,8 @@ import com.google.android.material.chip.Chip
 import com.google.android.material.slider.Slider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.lineageos.selfie.ui.GridView
 import org.lineageos.selfie.utils.CameraFacing
 import org.lineageos.selfie.utils.CameraMode
@@ -132,6 +134,7 @@ class MainActivity : AppCompatActivity() {
     private var viewFinderTouchEvent: MotionEvent? = null
 
     private var recording: Recording? = null
+    private val recordingLock = Mutex()
     private var recordingTime = 0L
         set(value) {
             field = value
@@ -454,7 +457,7 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-    private suspend fun captureVideo() {
+    private suspend fun captureVideo() = recordingLock.withLock {
         if (cameraController.isRecording) {
             // Stop the current recording session.
             recording?.stop()


### PR DESCRIPTION
Because captureVideo() isn't blocking the UI thread, it's possible to
call it multiple times which will cause app to crash.

Change-Id: Ie18b05e15072f30231ca83dd2d9120d0356b49a4