### PR TITLE
Selfie: Set isReversedHorizontal to false in photo metadata

### DIFF
--- a/app/src/main/java/org/lineageos/selfie/MainActivity.kt
+++ b/app/src/main/java/org/lineageos/selfie/MainActivity.kt
@@ -451,6 +451,7 @@ class MainActivity : AppCompatActivity() {
         val outputOptions = StorageUtils.getPhotoMediaStoreOutputOptions(
             contentResolver,
             ImageCapture.Metadata().apply {
+                isReversedHorizontal = false
                 location = this@MainActivity.location
             }
         )


### PR DESCRIPTION
For some reason this affects orientation of photos I take with front
camera.

Change-Id: I58ae753b61b2b594b2843113b45bcc338a82c3ec